### PR TITLE
fix seTE calc bugs when method.smd == Glass

### DIFF
--- a/R/metacont.R
+++ b/R/metacont.R
@@ -1746,7 +1746,7 @@ metacont <- function(n.e, mean.e, sd.e, n.c, mean.c, sd.c, studlab,
       ##
       TE <- smd
       seTE <- ifelse(npn.n, NA,
-                     sqrt(N / (n.e * n.c) + TE^2 / (2 * n.g - 1)))
+                     sqrt(N / (n.e * n.c) + TE^2 / (2 * (n.g - 1))))
     }
     ##
     seTE[is.na(TE)] <- NA


### PR DESCRIPTION
Jiang Yingda and me found a small issue of seTE in metacont api, while calculate  seTE of individual studies when method.smd = Glass. which TE^2 / (2 * n.g - 1) should be TE^2 / (2 * (n.g - 1))  we believe this is a bug of R with below reference. 

The first reference is:
Marfo, Philomena, and G. A. Okyere. "The accuracy of effect-size estimates under normals and contaminated normals in meta-analysis." Heliyon 5.6 (2019): e01838.
![image](https://user-images.githubusercontent.com/13758473/109621370-bb1dd900-7aef-11eb-9d39-3d8fcf1a940f.png)

The second reference is the original paper:
Hedges, Larry V. "Distribution theory for Glass's estimator of effect size and related estimators." journal of Educational Statistics 6.2 (1981): 107-128.
![image](https://user-images.githubusercontent.com/13758473/109621962-70e92780-7af0-11eb-8e4e-40cf61aef564.png)

Here k = 1 for a single study; 1/ñ is the first term; m in the second term is actually n2-1.

The 3rd reference is from "STATA META-ANALYSIS REFERENCE MANUAL" RELEASE 16, on page 87, it state the formula of Variance is as below
![image](https://user-images.githubusercontent.com/13758473/109621849-544cef80-7af0-11eb-9ad8-140114931658.png)



