### PR TITLE
Fix bug in setting method.sd for metacont update

### DIFF
--- a/R/update.meta.R
+++ b/R/update.meta.R
@@ -1314,7 +1314,7 @@ update.meta <- function(object,
                   method.mean =
                     replaceVal(replaceNULL(method.mean, "Luo"), "", "Luo"),
                   method.sd =
-                    replaceVal(replaceNULL(method.mean, "Shi"), "", "Shi"),
+                    replaceVal(replaceNULL(method.sd, "Shi"), "", "Shi"),
                   #
                   approx.mean.e = approx.mean.e,
                   approx.mean.c = approx.mean.c,


### PR DESCRIPTION
Hi Guido, 

Thanks for an excellent package. Recently I was working through some meta-anaysis examples using the `metacont` function and I found out that using the `update` function for `metacont` objects always errors out saying that the method.sd must be 'Shi', 'Wan', 'Cai', 'QE-McGrath', or 'BC-McGrath'.

I tested out the proposed fix and it works, and metacont objects can now be updated correctly.
