### PR TITLE
Fix rm5 reader

### DIFF
--- a/R/read.rm5-internal.R
+++ b/R/read.rm5-internal.R
@@ -525,6 +525,11 @@ oct2txt <- function(txt) {
   txt <- gsub("\376", "t", txt, useBytes = TRUE)
   txt <- gsub("\377", "y", txt, useBytes = TRUE)
   txt <- gsub("\303\237", "AY", txt, useBytes = TRUE)
+  
+  # replace any remaining non UTF-8 characters with question marks
+  # otherwise they crash the `extract_outcomes` function
+  txt <- iconv(txt, from = "", to = "UTF-8", sub = "???")
+  
   ##
   txt
 }

--- a/R/read.rm5-internal.R
+++ b/R/read.rm5-internal.R
@@ -928,6 +928,14 @@ read.rm5.rm5 <- function(file, title, numbers.in.labels = TRUE, debug = 0) {
   rdata <- oct2txt(rdata)
   
   
+  ## 
+  ## Deal with missing line breaks
+  ##
+  if (length(rdata) == 1 && sum(gregexpr(">", rdata)[[1]] > 0)) {
+    rdata <- unlist(strsplit(rdata, "(?<=>)", perl = TRUE))
+  }
+
+  
   ##
   ## Extract title
   ##


### PR DESCRIPTION
Hi Guido,

I was reading a couple of thousand rm5 files, and I found a couple of issues in the `read. RM5` function.
With the following fixes I was able to read pretty much everything but a few odd files.
(Some of the encoding issues might be Windows-specific.)

To reproduce the errors, use: 

non-escaped rm5 files
```
temp_df <- read.rm5("14651858.CD000023.pub5_data.rm5")
```
[14651858.CD000023.pub5_data.zip](https://github.com/user-attachments/files/21246081/14651858.CD000023.pub5_data.zip)

non-UTF-8 encoded rm5 files 
```
temp_df <- read.rm5("14651858.CD000052.pub3_data.rm5")`
```
[14651858.CD000052.pub3_data.zip](https://github.com/user-attachments/files/21246100/14651858.CD000052.pub3_data.zip)

Cheers,
Frantisek