### PR TITLE
Fix device closure in `forest.meta` and clean up documentation

### DIFF
--- a/R/forest.R
+++ b/R/forest.R
@@ -693,8 +693,8 @@
 #' will add 5 percent to the automatically determined width.
 #' 
 #' It is also possible to provide \code{NA} as input to arguments \code{height}
-#' and \code{weight}. In this case, the default dimensions of the graphics
-#' device are utilised, for example, seven inches for \code{\link{pdf}}.
+#' and \code{width}. In this case, the size of the current graphics
+#' device is used.
 #' 
 #' For backward compatibility, the height of the file is determined using a
 #' different approach if argument \code{rows.gr} is provided to
@@ -11938,18 +11938,23 @@ forest.meta <- function(x,
     device.args.all <-
       c(list(file = filename, height = height, width = width), device.args)
     #
-    local({
-      old_dev <- dev.cur()
+    old_dev <- dev.cur()
+    runNN(device, device.args.all)
+    #
+    if (dev.off) {
       on.exit({
         dev.off()
         if (old_dev > 1) dev.set(old_dev)
       }, add = TRUE)
-      runNN(device, device.args.all)
-    })
+    }
   }
   else if (autosize == "none") {
     figheight <- NULL
     rows.gr <- NULL
+    #
+    if (dev.off) {
+      on.exit(dev.off(), add = TRUE)
+    }
   }
   
   
@@ -11969,9 +11974,6 @@ forest.meta <- function(x,
   res$autosize <- autosize
   #
   class(res) <- "forest.meta"
-  #
-  if (dev.off)
-    invisible(dev.off())
   #
   invisible(res)
 }

--- a/R/meta-package.R
+++ b/R/meta-package.R
@@ -681,7 +681,7 @@
 #'
 #' @import metabook
 #' 
-#' @importFrom cli cli_warn cli_alert_success cli_abort cli_inform cli_abort
+#' @importFrom cli cli_warn cli_alert_success cli_abort cli_inform
 #' 
 #' @importFrom rlang := is_bare_list expr enexprs
 #' 

--- a/man/forest.meta.Rd
+++ b/man/forest.meta.Rd
@@ -1271,8 +1271,8 @@ automatically determined height and width, e.g., \code{width = .width * 1.05}
 will add 5 percent to the automatically determined width.
 
 It is also possible to provide \code{NA} as input to arguments \code{height}
-and \code{weight}. In this case, the default dimensions of the graphics
-device are utilised, for example, seven inches for \code{\link{pdf}}.
+and \code{width}. In this case, the size of the current graphics
+device is used.
 
 For backward compatibility, the height of the file is determined using a
 different approach if argument \code{rows.gr} is provided to


### PR DESCRIPTION
Hi @guido-s ,

Following up on the device handling discussion, I added some edits here:

- I noticed that using `local()` in the `autosize = "old"` branch caused the `on.exit()` handler to trigger prematurely since `local` creates its own scope. This meant the file device was being opened and immediately closed before the actual plot was drawn. I removed `local()` and attached the `on.exit()` handlers directly to the main function for both the "old" and "none" branches. This keeps the device open during plotting but ensures it safely closes at the end of the function whether an error occurred or not. (The "new" branch already handles this perfectly inside `save_plot()`).

- I fixed a small typo in the docs (it said "weight" instead of "width"). I also tweaked the explanation of how `NA` works. Passing `NA` uses `dev.size()` to copy the user's active device  and only falls back to 7x7 if they are no active devices, I think the main aim for this in `ggsave` was to resize plots pane in Rstudio and use those dimensions in saving, hence giving user dynamic way to resize plot manually or at least it is how I use it.

- I removed a duplicate `cli_abort` from the `@importFrom cli` block in `meta-package.R`. Also, I noticed that `cli_inform` line was removed from the `save_plot` adaptation which was giving user what sizes used whether the fallback or the current one, you may want then to remove `cli_inform` from imports as it is not currently used 