### PR TITLE
Align `DOR` and `VE` handling in `metabin`

### DIFF
--- a/R/meta-object.R
+++ b/R/meta-object.R
@@ -321,7 +321,8 @@
 #' \code{allstudies} \tab Include studies with double zeros \cr
 #' \code{doublezeros} \tab Indicator for studies with double zeros \cr
 #' \code{MH.exact} \tab Exact Mantel-Haenszel method \cr
-#' \code{RR.Cochrane} \tab Cochrane method to calculate risk ratio \cr
+#' \code{RR.Cochrane} \tab Cochrane method to calculate risk ratio or
+#'   vaccine efficacy / effectiveness \cr
 #' \code{Q.Cochrane} \tab Cochrane method to calculate \eqn{\tau^2}
 #'   \cr
 #' \code{Q.CMH} \tab Cochran-Mantel-Haenszel statistic \cr

--- a/R/metabin.R
+++ b/R/metabin.R
@@ -54,7 +54,7 @@
 #' @param allstudies A logical indicating if studies with zero or all
 #'   events in both groups are to be included in the meta-analysis
 #'   (applies only if \code{sm} is equal to \code{"RR"}, \code{"OR"},
-#'   or \code{"DOR"}).
+#'   \code{"DOR"}, or \code{"VE"}).
 #' @param incr.e Continuity correction in experimental group, see Details.
 #' @param incr.c Continuity correction in control group, see Details.
 #' @param MH.exact A logical indicating if \code{incr} is not to be
@@ -63,9 +63,10 @@
 #'   method.
 #' @param RR.Cochrane A logical indicating if 2*\code{incr} instead of
 #'   1*\code{incr} is to be added to \code{n.e} and \code{n.c} in the
-#'   calculation of the risk ratio (i.e., \code{sm="RR"}) for studies
-#'   with a zero cell. This is used in RevMan 5, the program for
-#'   preparing and maintaining Cochrane reviews.
+#'   calculation of the risk ratio or vaccine efficacy / effectiveness
+#'   (i.e., \code{sm="RR"} or \code{sm="VE"}) for studies with a zero
+#'   cell. This is used in RevMan 5, the program for preparing and
+#'   maintaining Cochrane reviews.
 #' @param Q.Cochrane A logical indicating if the Mantel-Haenszel
 #'   estimate is used in the calculation of the heterogeneity
 #'   statistic Q which is implemented in RevMan 5, the program for
@@ -136,11 +137,12 @@
 #'   \code{"Harbord"}, \code{"Peters"}, or \code{"Deeks"}, can be
 #'   abbreviated. See function \code{\link{metabias}.}
 #' @param backtransf A logical indicating whether results for odds
-#'   ratio (\code{sm="OR"}), risk ratio (\code{sm="RR"}), or
-#'   diagnostic odds ratio (\code{sm="DOR"}) should be back
-#'   transformed in printouts and plots. If TRUE (default), results
-#'   will be presented as odds ratios and risk ratios; otherwise log
-#'   odds ratios and log risk ratios will be shown.
+#'   ratio (\code{sm="OR"}), risk ratio (\code{sm="RR"}),
+#'   diagnostic odds ratio (\code{sm="DOR"}), or vaccine efficacy /
+#'   effectiveness (\code{sm="VE"}) should be back transformed in
+#'   printouts and plots. If TRUE (default), results will be presented
+#'   as odds ratios and risk ratios; otherwise log odds ratios and log
+#'   risk ratios will be shown.
 #' @param pscale A numeric defining a scaling factor for printing of
 #'   risk differences.
 #' @param text.common A character string used in printouts and forest
@@ -365,11 +367,12 @@
 #' \code{incr}) is added to all cell frequencies for the odds ratio or
 #' only the number of events for the risk ratio (argument
 #' \code{RR.Cochrane = FALSE}, default). The increment is added to all
-#' cell frequencies for the risk ratio if argument \code{RR.Cochrane =
-#' TRUE}. For the risk difference, \code{incr} is only added to all
-#' cell frequencies to calculate the standard error. Finally, a
-#' treatment arm continuity correction is used if \code{incr = "TACC"}
-#' (Sweeting et al., 2004; Diamond et al., 2007).
+#' cell frequencies for the risk ratio or vaccine efficacy / effectiveness
+#' if argument \code{RR.Cochrane = TRUE}. For the risk difference,
+#' \code{incr} is only added to all cell frequencies to calculate the
+#' standard error. Finally, a treatment arm continuity correction is used
+#' if \code{incr = "TACC"} (Sweeting et al., 2004; Diamond et al.,
+#' 2007).
 #'
 #' For odds ratio and risk ratio, treatment estimates and standard
 #' errors are only calculated for studies with zero or all events in
@@ -1576,11 +1579,15 @@ metabin <- function(event.e, n.e, event.c, n.c, studlab,
   # Check for pairwise comparisons with zero cell frequencies in both groups
   #
   doublezeros <- FALSE
-  if (sparse & sm %in% c("RR", "OR") & !(method %in% c("Peto", "GLMM"))) {
+  if (sparse & sm %in% c("RR", "OR", "DOR", "VE") &
+      !(method %in% c("Peto", "GLMM"))) {
     sel.doublezeros <- switch(sm,
                               OR = (event.e == 0   & event.c ==   0) |
                                 (event.c == n.c & event.e == n.e),
-                              RR = (event.c == 0 & event.e == 0))
+                              DOR = (event.e == 0   & event.c ==   0) |
+                                (event.c == n.c & event.e == n.e),
+                              RR = (event.c == 0 & event.e == 0),
+                              VE = (event.c == 0 & event.e == 0))
     if (any(sel.doublezeros, na.rm = TRUE))
       doublezeros <- TRUE
   }

--- a/R/metabin.R
+++ b/R/metabin.R
@@ -266,8 +266,8 @@
 #' V)} with \code{O-E} and \code{V} denoting "Observed minus Expected"
 #' and its variance, are utilised in the random effects
 #' model. Accordingly, results of a random effects model using
-#' \code{sm = "Peto"} can be different to results from a random
-#' effects model using \code{sm = "MH"} or \code{sm =
+#' \code{method = "Peto"} can be different to results from a random
+#' effects model using \code{method = "MH"} or \code{method =
 #' "Inverse"}. Note, the random effects estimate is based on the
 #' inverse variance method for all methods discussed so far.
 #' 
@@ -580,8 +580,8 @@
 #' ma4 <- update(ma3, method = "MH")
 #' ma4
 #' 
-#' # Meta-analysis based on Peto method (only available for odds ratio
-#' # as summary measure)
+#' # Meta-analysis based on Peto method (only available for odds ratio or
+#' # diagnostic odds ratio as summary measure)
 #' #
 #' ma5 <- update(ma3, method = "Peto")
 #' ma5
@@ -1820,12 +1820,16 @@ metabin <- function(event.e, n.e, event.c, n.c, studlab,
   #
   #
   
-  if (sm != "OR") {
+  if (!(sm %in% c("OR", "DOR"))) {
     if (method == "Peto")
-      stop("Peto's method only possible with argument 'sm = \"OR\"'")
+      stop("Peto's method only possible with argument 'sm = \"OR\"' or ",
+           "'sm = \"DOR\"'")
     else if (method == "SSW")
-      stop("Sample size weighting only available with argument 'sm = \"OR\"'")
-    else if (is.glmm)
+      stop("Sample size weighting only available with argument ",
+           "'sm = \"OR\"' or 'sm = \"DOR\"'")
+  }
+  if (sm != "OR") {
+    if (is.glmm)
       stop("Generalised linear mixed models only possible with ",
            "argument 'sm = \"OR\"'.")
     else if (is.lrp)

--- a/R/print.summary.meta.R
+++ b/R/print.summary.meta.R
@@ -636,7 +636,8 @@ print.summary.meta <- function(x,
   #
   if (k.all == 1 &&
       !(inherits(x, c("metaprop", "metarate")) |
-        (inherits(x, "metabin") && x$sm == "RR" && !x$RR.Cochrane &&
+        (inherits(x, "metabin") && x$sm %in% c("RR", "VE") &&
+         !x$RR.Cochrane &&
          !is_zero(x$TE - x$TE.common)) |
         (inherits(x, c("metacont", "metamean")) && x$method.ci == "t"))) {
     print.meta(x.meta,
@@ -660,7 +661,8 @@ print.summary.meta <- function(x,
     uppTE <- x$upper
     #
     if (k.all == 1 &&
-        inherits(x, "metabin") && x$sm == "RR" && !x$RR.Cochrane &&
+        inherits(x, "metabin") && x$sm %in% c("RR", "VE") &&
+        !x$RR.Cochrane &&
         !is_zero(x$TE - x$TE.common))
       x$method.ci <- "!RR.Cochrane"
     #

--- a/R/settings.meta.R
+++ b/R/settings.meta.R
@@ -72,7 +72,8 @@
 #' \code{tau.common} \tab FALSE \tab common between-study variance in
 #'   subgroups \cr
 #' \code{MH.exact} \tab FALSE \tab exact Mantel-Haenszel method \cr
-#' \code{RR.Cochrane} \tab TRUE \tab calculation of risk ratios \cr
+#' \code{RR.Cochrane} \tab TRUE \tab calculation of risk ratios or
+#'   vaccine efficacy / effectiveness \cr
 #' \code{Q.Cochrane} \tab TRUE \tab calculation of heterogeneity
 #'   statistic \cr
 #' \code{exact.smd} \tab FALSE \tab exact formulae for Hedges' g and

--- a/R/update.meta.R
+++ b/R/update.meta.R
@@ -36,7 +36,7 @@
 #' @param allstudies A logical indicating if studies with zero or all
 #'   events in both groups are to be included in the meta-analysis
 #'   (applies only to \code{\link{metabin}} object with \code{sm}
-#'   equal to \code{"RR"} or \code{"OR"}).
+#'   equal to \code{"RR"}, \code{"OR"}, \code{"DOR"}, or \code{"VE"}).
 #' @param incr.e Continuity correction in experimental group (see
 #'   \code{\link{metabin}} and \code{\link{metainc}}).
 #' @param incr.c Continuity correction in control group (see
@@ -48,8 +48,8 @@
 #'   to calculate the pooled estimate based on the Mantel-Haenszel
 #'   method (applies only to \code{\link{metabin}} object).
 #' @param RR.Cochrane A logical indicating which method to use as
-#'   continuity correction for the risk ratio (see
-#'   \code{\link{metabin}}).
+#'   continuity correction for the risk ratio or vaccine efficacy /
+#'   effectiveness (see \code{\link{metabin}}).
 #' @param Q.Cochrane A logical indicating which method to use to
 #'   calculate the heterogeneity statistic Q (see
 #'   \code{\link{metabin}}).
@@ -1273,7 +1273,7 @@ update.meta <- function(object,
     }
     #
     if (!(method == "MH" & method.tau == "DL" &
-          (sm %in% c("OR", "RR", "RD", "DOR"))))
+          (sm %in% c("OR", "RR", "RD", "DOR", "VE"))))
       Q.Cochrane <- FALSE
     #
     if (sm == "DOR" & missing.method.bias)

--- a/man/meta-object.Rd
+++ b/man/meta-object.Rd
@@ -323,7 +323,8 @@ class \code{"metabin"} and the following components.
 \code{allstudies} \tab Include studies with double zeros \cr
 \code{doublezeros} \tab Indicator for studies with double zeros \cr
 \code{MH.exact} \tab Exact Mantel-Haenszel method \cr
-\code{RR.Cochrane} \tab Cochrane method to calculate risk ratio \cr
+\code{RR.Cochrane} \tab Cochrane method to calculate risk ratio or
+  vaccine efficacy / effectiveness \cr
 \code{Q.Cochrane} \tab Cochrane method to calculate \eqn{\tau^2}
   \cr
 \code{Q.CMH} \tab Cochran-Mantel-Haenszel statistic \cr

--- a/man/metabin.Rd
+++ b/man/metabin.Rd
@@ -150,7 +150,7 @@ correction method should be used (\code{"only0"},
 \item{allstudies}{A logical indicating if studies with zero or all
 events in both groups are to be included in the meta-analysis
 (applies only if \code{sm} is equal to \code{"RR"}, \code{"OR"},
-or \code{"DOR"}).}
+\code{"DOR"}, or \code{"VE"}).}
 
 \item{incr.e}{Continuity correction in experimental group, see Details.}
 
@@ -166,9 +166,10 @@ method.}
 
 \item{RR.Cochrane}{A logical indicating if 2*\code{incr} instead of
 1*\code{incr} is to be added to \code{n.e} and \code{n.c} in the
-calculation of the risk ratio (i.e., \code{sm="RR"}) for studies
-with a zero cell. This is used in RevMan 5, the program for
-preparing and maintaining Cochrane reviews.}
+calculation of the risk ratio or vaccine efficacy / effectiveness
+(i.e., \code{sm="RR"} or \code{sm="VE"}) for studies with a zero
+cell. This is used in RevMan 5, the program for preparing and
+maintaining Cochrane reviews.}
 
 \item{Q.Cochrane}{A logical indicating if the Mantel-Haenszel
 estimate is used in the calculation of the heterogeneity
@@ -262,11 +263,12 @@ funnel plot asymmetry is to be used. Either \code{"Begg"},
 abbreviated. See function \code{\link{metabias}.}}
 
 \item{backtransf}{A logical indicating whether results for odds
-ratio (\code{sm="OR"}), risk ratio (\code{sm="RR"}), or
-diagnostic odds ratio (\code{sm="DOR"}) should be back
-transformed in printouts and plots. If TRUE (default), results
-will be presented as odds ratios and risk ratios; otherwise log
-odds ratios and log risk ratios will be shown.}
+ratio (\code{sm="OR"}), risk ratio (\code{sm="RR"}),
+diagnostic odds ratio (\code{sm="DOR"}), or vaccine efficacy /
+effectiveness (\code{sm="VE"}) should be back transformed in
+printouts and plots. If TRUE (default), results will be presented
+as odds ratios and risk ratios; otherwise log odds ratios and log
+risk ratios will be shown.}
 
 \item{pscale}{A numeric defining a scaling factor for printing of
 risk differences.}
@@ -537,11 +539,12 @@ For studies with a zero cell count, by default, 0.5 (argument
 \code{incr}) is added to all cell frequencies for the odds ratio or
 only the number of events for the risk ratio (argument
 \code{RR.Cochrane = FALSE}, default). The increment is added to all
-cell frequencies for the risk ratio if argument \code{RR.Cochrane =
-TRUE}. For the risk difference, \code{incr} is only added to all
-cell frequencies to calculate the standard error. Finally, a
-treatment arm continuity correction is used if \code{incr = "TACC"}
-(Sweeting et al., 2004; Diamond et al., 2007).
+cell frequencies for the risk ratio or vaccine efficacy / effectiveness
+if argument \code{RR.Cochrane = TRUE}. For the risk difference,
+\code{incr} is only added to all cell frequencies to calculate the
+standard error. Finally, a treatment arm continuity correction is used
+if \code{incr = "TACC"} (Sweeting et al., 2004; Diamond et al.,
+2007).
 
 For odds ratio and risk ratio, treatment estimates and standard
 errors are only calculated for studies with zero or all events in

--- a/man/metabin.Rd
+++ b/man/metabin.Rd
@@ -438,8 +438,8 @@ ratio, i.e. \code{(O-E) / V} and its standard error \code{sqrt(1 /
 V)} with \code{O-E} and \code{V} denoting "Observed minus Expected"
 and its variance, are utilised in the random effects
 model. Accordingly, results of a random effects model using
-\code{sm = "Peto"} can be different to results from a random
-effects model using \code{sm = "MH"} or \code{sm =
+\code{method = "Peto"} can be different to results from a random
+effects model using \code{method = "MH"} or \code{method =
 "Inverse"}. Note, the random effects estimate is based on the
 inverse variance method for all methods discussed so far.
 
@@ -644,8 +644,8 @@ ma3
 ma4 <- update(ma3, method = "MH")
 ma4
 
-# Meta-analysis based on Peto method (only available for odds ratio
-# as summary measure)
+# Meta-analysis based on Peto method (only available for odds ratio or
+# diagnostic odds ratio as summary measure)
 #
 ma5 <- update(ma3, method = "Peto")
 ma5

--- a/man/settings.meta.Rd
+++ b/man/settings.meta.Rd
@@ -80,7 +80,8 @@ RevMan 5 settings, in detail:
 \code{tau.common} \tab FALSE \tab common between-study variance in
   subgroups \cr
 \code{MH.exact} \tab FALSE \tab exact Mantel-Haenszel method \cr
-\code{RR.Cochrane} \tab TRUE \tab calculation of risk ratios \cr
+\code{RR.Cochrane} \tab TRUE \tab calculation of risk ratios or
+  vaccine efficacy / effectiveness \cr
 \code{Q.Cochrane} \tab TRUE \tab calculation of heterogeneity
   statistic \cr
 \code{exact.smd} \tab FALSE \tab exact formulae for Hedges' g and

--- a/man/update.meta.Rd
+++ b/man/update.meta.Rd
@@ -160,7 +160,7 @@ correction method should be used (see \code{\link{metabin}},
 \item{allstudies}{A logical indicating if studies with zero or all
 events in both groups are to be included in the meta-analysis
 (applies only to \code{\link{metabin}} object with \code{sm}
-equal to \code{"RR"} or \code{"OR"}).}
+equal to \code{"RR"}, \code{"OR"}, \code{"DOR"}, or \code{"VE"}).}
 
 \item{incr.e}{Continuity correction in experimental group (see
 \code{\link{metabin}} and \code{\link{metainc}}).}
@@ -177,8 +177,8 @@ to calculate the pooled estimate based on the Mantel-Haenszel
 method (applies only to \code{\link{metabin}} object).}
 
 \item{RR.Cochrane}{A logical indicating which method to use as
-continuity correction for the risk ratio (see
-\code{\link{metabin}}).}
+continuity correction for the risk ratio or vaccine efficacy /
+effectiveness (see \code{\link{metabin}}).}
 
 \item{Q.Cochrane}{A logical indicating which method to use to
 calculate the heterogeneity statistic Q (see


### PR DESCRIPTION
Hi @guido-s,

While checking different `metabin()` summary-measure and method combinations, I noticed a few small inconsistencies around `DOR` and `VE`.

`DOR` is handled through the odds-ratio path in the relevant calculation code, but validation for `method = "Peto"` and `method = "SSW"` only allowed `sm = "OR"`. This PR allows `sm = "DOR"` there as well. I also fixed nearby documentation examples where `sm` was mentioned instead of `method` when describing `method = "Peto"` and `method = "SSW"`.

While reviewing the surrounding code, I also found a few places where `VE` was missing even though it follows the risk-ratio path internally. The `doublezeros` metadata now treats `DOR` like `OR` and `VE` like `RR`, `update.meta()` now preserves valid `Q.Cochrane` settings for `VE`, and one-study summary printing now handles the `VE` / `RR.Cochrane = FALSE` case consistently with `RR`.

The documentation was also aligned for `allstudies`, `RR.Cochrane`, and `backtransf` so that `DOR` and `VE` are described consistently with the implemented behavior.

I did not change `GLMM` or `LRP` handling, because `metabin()` currently restricts those methods to `sm = "OR"`. Allowing `DOR` there would be a broader method-support change rather than the same kind of validation/metadata mismatch fixed here.

One separate possible issue I noticed while checking this: `metabias()` documentation says `plotit = TRUE` can produce a plot for Deeks' test, but the plotting code does not appear to have a Deeks plotting branch. I left that out of this PR because it is separate from the `metabin()` DOR/VE handling changes.

Please let me know if this interpretation is conceptually right, as some of these omissions may have been intentional.